### PR TITLE
Use Datastore for loading secret keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ project/__pycache__/
 **.pyc
 lib/
 .logs/
+yapf.sh
 
 # GCP
 google-cloud-sdk/

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
-runtime: python
-env: flex
+runtime: python37
 entrypoint: gunicorn -b :$PORT main
 api_version: 1
 threadsafe: true
@@ -8,10 +7,11 @@ runtime_config:
   python_version: 3
 
 handlers:
-- url: project/static
-  static_dir: project/static
+- url: /project/static
+  static_dir: /project/static
 - url: /.*
   script: main.app
 
 skip_files:
 - .git/
+- .logs/

--- a/main.py
+++ b/main.py
@@ -7,16 +7,18 @@ import os
 
 import project
 from project.config import Config
+import project.util as util
+from project.util import Env
 
 _PORT = int(os.environ.get('PORT', 5000))
 
 # gunicorn looks for 'application' to run.
-application = project.create_app(Config)  # pylint: disable=invalid-name
+application = project.create_app(Config(util.get_env()))  # pylint: disable=invalid-name
 
 
 def init_logging(default_level=logging.INFO):
     """Loads the logging config if present or uses default settings."""
-    if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
+    if util.get_env() == Env.PROD:
         # App is running in production environment.
         config_path = 'logging_prod.json'
     else:

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -3,7 +3,7 @@
 import logging
 
 from flask import Flask, redirect, render_template, session, url_for
-
+from flask import current_app
 from project.forms import QueryForm
 
 
@@ -16,6 +16,7 @@ def create_app(config):
     def home():  # pylint: disable=unused-variable
         """Home page."""
         form = QueryForm()
+        logging.info(current_app.config['SECRET_KEY'])
         if form.validate_on_submit():
             session['query_result'] = form.query.data
             logging.debug('User queried:|%s|', session['query_result'])

--- a/project/config.py
+++ b/project/config.py
@@ -1,15 +1,15 @@
 """Config objects for Flask app."""
 
 import logging
+import os
 
 from google.cloud import datastore
 from project.util import Env
 
-NOT_SET_ = 'NOT_SET'
-
 
 class Config(object):  # pylint: disable=too-few-public-methods
     """Default Flask configuration."""
+
     def __init__(self, env):
         """Sets app keys depending on what environment the app is running in."""
         self.client = datastore.Client()
@@ -24,23 +24,38 @@ class Config(object):  # pylint: disable=too-few-public-methods
         # News API
         self.NEWS_API_KEY = self.get_datastore_value_('NEWS_API_KEY')
         # Twitter API
-        self.TWITTER_CONSUMER_KEY = self.get_datastore_value_('TWITTER_CONSUMER_KEY')
-        self.TWITTER_CONSUMER_SECRET = self.get_datastore_value_('TWITTER_CONSUMER_SECRET')
-        self.TWITTER_ACCESS_TOKEN = self.get_datastore_value_('TWITTER_ACCESS_TOKEN')
-        self.TWITTER_ACCESS_TOKEN_SECRET = self.get_datastore_value_('TWITTER_ACCESS_TOKEN_SECRET')
+        self.TWITTER_CONSUMER_KEY = self.get_datastore_value_(
+            'TWITTER_CONSUMER_KEY')
+        self.TWITTER_CONSUMER_SECRET = self.get_datastore_value_(
+            'TWITTER_CONSUMER_SECRET')
+        self.TWITTER_ACCESS_TOKEN = self.get_datastore_value_(
+            'TWITTER_ACCESS_TOKEN')
+        self.TWITTER_ACCESS_TOKEN_SECRET = self.get_datastore_value_(
+            'TWITTER_ACCESS_TOKEN_SECRET')
 
     def get_datastore_value_(self, key):
         """Retrieves the key's value from Datastore.
 
+        Override value by setting environment variable.
+
         :param key: String key
-        :return String value. NOT_SET_ if key was not found.
+        :return String value. 'NOT_SET' if key was not found.
         """
         entity = self.client.get(self.client.key(self.entity_kind, key))
         if entity is None:
-            logging.warning('Key {%s} is not set.' % key)
-            return NOT_SET_
+            logging.warning(
+                'Key {%s} is not set in Datastore. Go to the GCP Developers '
+                'Console to set it.' % key)
+            value = 'NOT_SET'
         else:
-            return entity.get('value')
+            value = entity.get('value')
+
+        env_var_override = os.environ.get(key)
+        if env_var_override is not None:
+            logging.info('Key {%s} overridden by environment variable.')
+            value = env_var_override
+        return value
 
     def __str__(self):
+        # TODO(alexzhu): Implement this.
         return 'Not Implemented'

--- a/project/config.py
+++ b/project/config.py
@@ -1,9 +1,23 @@
 """Config objects for Flask app."""
 
-import os
+from google.cloud import datastore
+from project.util import Env
 
 
 class Config(object):  # pylint: disable=too-few-public-methods
     """Default Flask configuration."""
-    DEBUG = True
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'test-key'
+
+    def __init__(self, env):
+        client = datastore.Client()
+        if env == Env.PROD:
+            entity_kind = 'Settings_prod'
+        else:
+            entity_kind = 'Settings_dev'
+
+        self.DEBUG = True
+
+        # Token for CSRF protection.
+        self.SECRET_KEY = client.get(
+            client.key(entity_kind, 'CSRF_PROTECTION_KEY')).get('key') or 'test-key'
+        self.TWITTER_API_KEY = client.get(
+            client.key(entity_kind, 'TWITTER_API_KEY')).get('key') or 'test-key'

--- a/project/config.py
+++ b/project/config.py
@@ -35,11 +35,12 @@ class Config(object):  # pylint: disable=too-few-public-methods
         :param key: String key
         :return String value. NOT_SET_ if key was not found.
         """
-        value = self.client.get(self.client.key(self.entity_kind, key)).get('value')
-        if value is None:
+        entity = self.client.get(self.client.key(self.entity_kind, key))
+        if entity is None:
             logging.warning('Key {%s} is not set.' % key)
-            value = NOT_SET_
-        return value
+            return NOT_SET_
+        else:
+            return entity.get('value')
 
     def __str__(self):
         return 'Not Implemented'

--- a/project/query.py
+++ b/project/query.py
@@ -3,8 +3,10 @@
 import tweepy
 from flask import current_app as app
 
+
 class Query(object):  # pylint: disable=too-few-public-methods
     """Class to query multiple API's."""
+
     def __init__(self):
         # Authenticates multiple API's
 
@@ -15,15 +17,13 @@ class Query(object):  # pylint: disable=too-few-public-methods
                                       app.config['TWIT_ACCESS_TOKEN_SECRET'])
         self.twitter_api = tweepy.API(twitter_auth)
 
-
     def twitter_search(self, query, num=100):
         """Given a query and optional number of tweets to return,
         returns a list of tweet messages received from the Twitter API.
         """
-        search = self.twitter_api.search(q=query, lang='en', count=str(num),
-                                         tweet_mode='extended')
+        search = self.twitter_api.search(
+            q=query, lang='en', count=str(num), tweet_mode='extended')
         return [item.full_text for item in search]
-
 
     def query(self, query):
         """Given a query, accesses multiple API's with that query and returns

--- a/project/sentiment_detector.py
+++ b/project/sentiment_detector.py
@@ -2,7 +2,6 @@
 Utilizes the Google Cloud Platform Natural Language Processing API.
 """
 from collections import namedtuple
-
 """Tuple containing sentiment score (pos/neg/neutral rating) and magnitude,
 as defined by the GCP NLP API.
 """

--- a/project/util.py
+++ b/project/util.py
@@ -1,0 +1,15 @@
+"""Utility for Tidbits."""
+from enum import Enum, auto
+import os
+
+
+class Env(Enum):
+    PROD = auto()
+    DEV = auto()
+
+
+def get_env():
+    if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
+        return Env.PROD
+    else:
+        return Env.DEV

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Werkzeug>=0.9.1
 itsdangerous>=0.22
 wtforms
 flask_wtf
+google-cloud-datastore


### PR DESCRIPTION
- Can override the Datastore values by setting environment variables.
- No longer using environment variables as the main way of loading api keys.
Fixes #9 